### PR TITLE
Add mongodb support for job postings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Set environment variables:
 - TELEGRAM_BOT_TOKEN
 - TELEGRAM_CHANNEL_ID
 - GEMINI_API_KEY
+  
+Optional (to use MongoDB for tracking posted jobs instead of local file):
+
+- MONGODB_URI (e.g., `mongodb+srv://user:pass@cluster.example.com/?retryWrites=true&w=majority`)
+- MONGODB_DB (default: `jobposter`)
+- MONGODB_COLLECTION (default: `posted_jobs`)
 
 Install dependencies:
 
@@ -33,4 +39,5 @@ python job_poster.py --use-sample
 Notes
 -----
 - The script stores posted post IDs in `posted.json` next to the script.
+- If `MONGODB_URI` is provided (and `pymongo` is installed), posted IDs will be stored in MongoDB collection instead. Each posted job is stored as a document with `_id` equal to the WordPress post id.
 - If Gemini client is not installed or the API call fails, posts are skipped and errors are logged to console.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv>=0.21.0
 # If your Python version is incompatible with one, pip will try the other.
 google-generative-ai
 google-genai
+pymongo>=4.6.0


### PR DESCRIPTION
Add optional MongoDB support for storing posted job IDs, with automatic fallback to local file storage.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bcf3129-5828-486a-9cf7-7d6b04be8796">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7bcf3129-5828-486a-9cf7-7d6b04be8796">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

